### PR TITLE
Include *.d.ts files in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 node_modules
 yarn*
 *.ts
+!*.d.ts
 tsconfig.json


### PR DESCRIPTION
When using the package in a TypeScript application, the tsc compiler complains that there are no types defined:

```
> tsc -p .

api/src/routes/SamlRouter.ts:3:28 - error TS7016: Could not find a declaration file for module '@authenio/samlify-node-xmllint'. './node_modules/@authenio/samlify-node-xmllint/build/index.js' implicitly has an 'any' type.
  Try `npm install @types/authenio__samlify-node-xmllint` if it exists or add a new declaration (.d.ts) file containing `declare module '@authenio/samlify-node-xmllint';`

3 import * as validator from '@authenio/samlify-node-xmllint';
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error.
```

This fixes that issue by including the generated type declaration files in the npm package.