### PR TITLE
fix: import schema files to support bundlers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,29 +2,21 @@ import * as mod from 'node-xmllint';
 import * as path from 'path';
 import * as fs from 'fs';
 
-const xsd = 'saml-schema-protocol-2.0.xsd';
-
-const schemaPath = (schema: string) => path.resolve(__dirname, `./schemas/${schema}`);
-
-let schemaProto = fs.readFileSync(schemaPath(xsd), 'utf-8');
-let schemaAssert = fs.readFileSync(schemaPath('saml-schema-assertion-2.0.xsd'), 'utf-8');
-const schemaXmldsig = fs.readFileSync(schemaPath('xmldsig-core-schema.xsd'), 'utf-8');
-let schemaXenc = fs.readFileSync(schemaPath('xenc-schema.xsd'), 'utf-8');
+import xsd from './schemas/saml-schema-protocol-2.0.xsd';
+import assertion from './schemas/saml-schema-assertion-2.0.xsd';
+import sig from './schemas/xmldsig-core-schema.xsd';
+import xenc from './schemas/xenc-schema.xsd';
 
 // file fix for virtual filesystem of emscripten
-schemaProto = schemaProto.replace('saml-schema-assertion-2.0.xsd', 'file_0.xsd');
-schemaProto = schemaProto.replace('xmldsig-core-schema.xsd', 'file_1.xsd');
-schemaAssert = schemaAssert.replace('xmldsig-core-schema.xsd', 'file_1.xsd');
-schemaAssert = schemaAssert.replace('xenc-schema.xsd', 'file_2.xsd');
-schemaXenc = schemaXenc.replace('xmldsig-core-schema.xsd', 'file_1.xsd');
+let schemaProto = xsd.replace('saml-schema-assertion-2.0.xsd', 'file_0.xsd').replace('xmldsig-core-schema.xsd', 'file_1.xsd');
+let schemaAssert = assertion.replace('xmldsig-core-schema.xsd', 'file_1.xsd').replace('xenc-schema.xsd', 'file_2.xsd');
+let schemaXenc = xenc.replace('xmldsig-core-schema.xsd', 'file_1.xsd');
 
 export const validate = (xml: string) => {
-
   return new Promise((resolve, reject) => {
-
     const validationResult = mod.validateXML({
       xml: xml,
-      schema: [schemaAssert, schemaXmldsig, schemaXenc, schemaProto]
+      schema: [schemaAssert, sig, schemaXenc, schemaProto]
     });
 
     if (!validationResult.errors) {
@@ -34,5 +26,4 @@ export const validate = (xml: string) => {
     console.error(`this is not a valid saml response with errors: ${validationResult.errors}`);
     return reject('ERR_EXCEPTION_VALIDATE_XML');
   });
-  
 };

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,4 @@
 import * as mod from 'node-xmllint';
-import * as fs from 'fs';
 
 import xsd from './schemas/saml-schema-protocol-2.0.xsd';
 import assertion from './schemas/saml-schema-assertion-2.0.xsd';

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,4 @@
 import * as mod from 'node-xmllint';
-import * as path from 'path';
 import * as fs from 'fs';
 
 import xsd from './schemas/saml-schema-protocol-2.0.xsd';

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Validator module powered by node-xmllint",
   "main": "build/index.js",
   "scripts": {
-    "build": "yarn run clean && yarn run cp-schemas && tsc",
-    "cp-schemas": "mkdir -p build/schemas && cp -R schemas build",
+    "build": "yarn run clean && tsc --diagnostics",
     "clean": "rm -rf build"
   },
   "repository": {

--- a/schemas/XMLSchema.dtd.ts
+++ b/schemas/XMLSchema.dtd.ts
@@ -1,4 +1,4 @@
-<!-- DTD for XML Schemas: Part 1: Structures
+export default `<!-- DTD for XML Schemas: Part 1: Structures
      Public Identifier: "-//W3C//DTD XMLSCHEMA 200102//EN"
      Official Location: http://www.w3.org/2001/XMLSchema.dtd -->
 <!-- $Id: XMLSchema.dtd,v 1.31 2001/10/24 15:50:16 ht Exp $ -->
@@ -399,4 +399,4 @@
 <!NOTATION XMLSchemaStructures PUBLIC
            'structures' 'http://www.w3.org/2001/XMLSchema.xsd' >
 <!NOTATION XML PUBLIC
-           'REC-xml-1998-0210' 'http://www.w3.org/TR/1998/REC-xml-19980210' >
+           'REC-xml-1998-0210' 'http://www.w3.org/TR/1998/REC-xml-19980210' >`;

--- a/schemas/datatypes.dtd.ts
+++ b/schemas/datatypes.dtd.ts
@@ -1,4 +1,4 @@
-<!--
+export default `<!--
         DTD for XML Schemas: Part 2: Datatypes
         $Id: datatypes.dtd,v 1.23 2001/03/16 17:36:30 ht Exp $
         Note this DTD is NOT normative, or even definitive. - - the
@@ -200,4 +200,4 @@
 <!ELEMENT %pattern; %facetModel;>
 <!ATTLIST %pattern;
         %facetAttr;
-        %patternAttrs;>
+        %patternAttrs;>`;

--- a/schemas/saml-schema-assertion-2.0.xsd.ts
+++ b/schemas/saml-schema-assertion-2.0.xsd.ts
@@ -1,4 +1,4 @@
-<schema
+export default `<schema
     targetNamespace="urn:oasis:names:tc:SAML:2.0:assertion"
     xmlns="http://www.w3.org/2001/XMLSchema"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -279,4 +279,4 @@
     </complexType>
     <element name="AttributeValue" type="anyType" nillable="true"/>
     <element name="EncryptedAttribute" type="saml:EncryptedElementType"/>
-</schema>
+</schema>`;

--- a/schemas/saml-schema-protocol-2.0.xsd.ts
+++ b/schemas/saml-schema-protocol-2.0.xsd.ts
@@ -1,4 +1,4 @@
-<schema
+export default `<schema
     targetNamespace="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns="http://www.w3.org/2001/XMLSchema"
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
@@ -298,4 +298,4 @@
             </extension>
         </complexContent>
     </complexType>
-</schema>
+</schema>`;

--- a/schemas/xenc-schema.xsd.ts
+++ b/schemas/xenc-schema.xsd.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE schema SYSTEM "XMLSchema.dtd"
  [
    <!ATTLIST schema
@@ -141,5 +141,5 @@
       <anyAttribute namespace="http://www.w3.org/XML/1998/namespace"/>
     </complexType>
 
-</schema>
+</schema>`;
 

--- a/schemas/xmldsig-core-schema.xsd.ts
+++ b/schemas/xmldsig-core-schema.xsd.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+export default `<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE schema SYSTEM "XMLSchema.dtd"
  [
    <!ATTLIST schema 
@@ -314,4 +314,4 @@
 
 <!-- End Signature -->
 
-</schema>
+</schema>`;


### PR DESCRIPTION
This PR changes the `/schemas` files to export a string. This directly supports use in bundlers following the precedent set by `node-xml-encryption`.  This fixes #2.

@tngan I would be happy to pay a bounty to get this update merged and published. 